### PR TITLE
Implement flush_all command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,6 @@
   * [Get Multi](getmulti.md)
   * [Delete](delete.md)
   * [Incr/Decr](incrdecr.md)
+  * [Flush](flush.md)
   * [Disconnect](disconnect.md)
   * [Elasticache](elasticache.md)
-

--- a/docs/flush.md
+++ b/docs/flush.md
@@ -1,0 +1,25 @@
+# Flush
+
+### Basic case
+
+Flush removes all stored values.
+
+```javascript
+client
+    .flush()
+    .then(function() {
+        console.log('Successfully cleared all data');
+    });
+```
+
+### Callbacks
+
+Memcache Plus will always return a [Promise](https://www.promisejs.org), but it
+can also take a traditional callback for any of its methods so it can work just
+like most of the other Memcache modules out there. For example:
+
+```javascript
+client.flush('firstName', function() {
+    console.log('Successfully cleared all data');
+});
+```

--- a/docs/flush.md
+++ b/docs/flush.md
@@ -12,6 +12,18 @@ client
     });
 ```
 
+### Delayed flush
+
+You can add a delay in seconds before the flush is executed.
+
+```javascript
+client
+    .flush(1)
+    .then(function() {
+        console.log('Successfully cleared all data');
+    });
+```
+
 ### Callbacks
 
 Memcache Plus will always return a [Promise](https://www.promisejs.org), but it
@@ -19,7 +31,7 @@ can also take a traditional callback for any of its methods so it can work just
 like most of the other Memcache modules out there. For example:
 
 ```javascript
-client.flush('firstName', function() {
+client.flush(function() {
     console.log('Successfully cleared all data');
 });
 ```

--- a/lib/client.js
+++ b/lib/client.js
@@ -384,6 +384,11 @@ Client.prototype.decr = function(key, val, cb) {
     return this.run('decr', [key, val], cb);
 };
 
+/**
+ * flush() - Removes all stored values
+ * @param {Function} [cb] - The (optional) callback called on completion
+ * @returns {Promise}
+ */
 Client.prototype.flush = function (cb) {
     return this.run('flush_all', [], cb);
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -384,6 +384,10 @@ Client.prototype.decr = function(key, val, cb) {
     return this.run('decr', [key, val], cb);
 };
 
+Client.prototype.flush = function (cb) {
+    return this.run('flush_all', [], cb);
+};
+
 /**
  * run() - Run this command on the appropriate connection. Will buffer command
  *   if connection(s) are not ready

--- a/lib/client.js
+++ b/lib/client.js
@@ -386,11 +386,17 @@ Client.prototype.decr = function(key, val, cb) {
 
 /**
  * flush() - Removes all stored values
+ * @param {Number|Function} [delay = 0] - Delay invalidation by specified seconds
  * @param {Function} [cb] - The (optional) callback called on completion
  * @returns {Promise}
  */
-Client.prototype.flush = function (cb) {
-    return this.run('flush_all', [], cb);
+Client.prototype.flush = function (delay, cb) {
+    if (typeof delay === 'function' || typeof delay === 'undefined') {
+        cb = delay;
+        delay = 0;
+    }
+
+    return this.run('flush_all', [delay], cb);
 };
 
 /**

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -499,6 +499,25 @@ Connection.prototype.get = function(key, opts) {
 };
 
 /**
+ * flush() - delete all values on this connection
+ * @param delay
+ * @returns {Promise}
+ */
+Connection.prototype.flush_all = function(delay) {
+    debug('flush_all %s', delay);
+
+    var deferred = misc.defer(delay);
+    this.queue.push(deferred);
+
+    this.write(util.format('flush_all %s', delay));
+
+    return deferred.promise
+      .then(function(v) {
+          return v === 'OK';
+      });
+};
+
+/**
  * delete() - Delete value for this key on this connection
  *
  * @param {String} key - The key to delete

--- a/test/client.js
+++ b/test/client.js
@@ -810,6 +810,38 @@ describe('Client', function() {
         });
     });
 
+    describe('flush', function() {
+        var cache;
+        before(function() {
+            cache = new Client();
+        });
+
+        it('exists', function() {
+            cache.should.have.property('flush');
+        });
+
+        describe('should work', function() {
+            it('removes all data', function () {
+                var key = getKey(), val = chance.natural();
+
+                cache.set(key, val)
+                  .then(function() {
+                      return cache.get(key);
+                  })
+                  .then(function(v) {
+                      expect(v).to.equal(val);
+                      return cache.flush();
+                  })
+                  .then(function () {
+                      return cache.get(key);
+                  })
+                  .then(function (v) {
+                      expect(v).to.equal(null);
+                  });
+            });
+        });
+    });
+
     after(function() {
         var cache = new Client();
 

--- a/test/client.js
+++ b/test/client.js
@@ -426,7 +426,7 @@ describe('Client', function() {
             var key = getKey(), key1 = getKey(), key2 = getKey(), key3 = getKey(),
                 val1 = chance.word(), val2 = chance.word(), val3 = chance.word();
 
-            
+
             return cache.set(key, val1)
                 .then(function() {
                     return Promise.all([
@@ -833,6 +833,32 @@ describe('Client', function() {
                       return cache.flush();
                   })
                   .then(function () {
+                      return cache.get(key);
+                  })
+                  .then(function (v) {
+                      expect(v).to.equal(null);
+                  });
+            });
+
+            it('removes all data after a specified seconds', function () {
+                var key = getKey(), val = chance.natural();
+
+                cache.set(key, val)
+                  .then(function() {
+                      return cache.get(key);
+                  })
+                  .then(function(v) {
+                      expect(v).to.equal(val);
+                      return cache.flush(1);
+                  })
+                  .then(function () {
+                      return cache.get(key);
+                  })
+                  .then(function (v) {
+                      expect(v).to.equal(v);
+
+                      // the testing framework usually takes longer than a second to run/execute
+                      // so not using any timeouts here (tried, didn't work very well)
                       return cache.get(key);
                   })
                   .then(function (v) {


### PR DESCRIPTION
Fixes https://github.com/victorquinn/memcache-plus/issues/23

Implements according to this spec: http://blog.elijaa.org/2010/05/21/memcached-telnet-command-summary/#flush_all

Note, I got errors on the unit tests locally (Travis CI passes all) before my changes were made (using node 6.2.2), but my added unit test pass:

```
  Connection
Unhandled rejection TypeError: Cannot read property 'apply' of undefined
  at Client.run (/Volumes/sixfive-cs/memcache-plus/lib/client.js:409:35)
  at Client.flush (/Volumes/sixfive-cs/memcache-plus/lib/client.js:388:17)
  at /Volumes/sixfive-cs/memcache-plus/test/client.js:833:36
  at bound (domain.js:280:14)
  at runBound (domain.js:293:12)
  at tryCatcher (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/util.js:16:23)
  at Promise._settlePromiseFromHandler (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise.js:510:31)
  at Promise._settlePromise (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise.js:567:18)
  at Promise._settlePromise0 (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise.js:612:10)
  at Promise._settlePromises (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise.js:691:18)
  at Promise._fulfill (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise.js:636:18)
  at Promise._resolveCallback (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise.js:431:57)
  at Promise._settlePromiseFromHandler (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise.js:522:17)
  at Promise._settlePromise (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise.js:567:18)
  at Promise._settlePromise0 (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise.js:612:10)
  at Promise._settlePromises (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise.js:691:18)
  at Promise._fulfill (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise.js:636:18)
  at PromiseArray._resolve (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise_array.js:125:19)
  at PromiseArray._promiseFulfilled (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise_array.js:143:14)
  at PromiseArray._iterate (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise_array.js:113:31)
  at PromiseArray.init [as _init] (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise_array.js:77:10)
  at bound (domain.js:280:14)
  at PromiseArray.runBound (domain.js:293:12)
  at Promise._settlePromise (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise.js:564:21)
  at Promise._settlePromise0 (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise.js:612:10)
  at Promise._settlePromises (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/promise.js:691:18)
  at Async._drainQueue (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/async.js:138:16)
  at Async._drainQueues (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/async.js:148:10)
  at Immediate.Async.drainQueues [as _onImmediate] (/Volumes/sixfive-cs/memcache-plus/node_modules/bluebird/js/release/async.js:17:14)
  at tryOnImmediate (timers.js:543:15)
  at processImmediate [as _immediateCallback] (timers.js:523:5)


    ✓ initializes with defaults
    ✓ initiates connection
    ✓ does connect
    ✓ reconnects, if enabled and connection lost
    does not reconnect when
      ✓ reconnect is disabled and connection lost (54ms)
      ✓ intentionally disconnected (59ms)


  70 passing (13s)
  6 failing

  1) Client incr should throw an error if called with a key that is too long:
     AssertionError: expected [Function] to throw an error
    at Context.<anonymous> (test/client.js:717:90)
  

  2) Client incr should work without an increment value:
     Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
  

  3) Client incr should work with an increment value:
     Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
  

  4) Client decr should throw an error if called with a key that is too long:
     AssertionError: expected [Function] to throw an error
    at Context.<anonymous> (test/client.js:773:90)
  

  5) Client decr should work without a decrement value:
     Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
  

  6) Client decr should work with a decrement value:
     Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
```