### PR TITLE
Replace "collections/deque" with "queue"

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -9,7 +9,7 @@ var _ = require('lodash'),
     HashRing = require('hashring'),
     misc = require('./misc'),
     Promise = require('bluebird'),
-    Queue = require('collections/deque'),
+    Queue = require('queue'),
     R = require('ramda');
 
 var Connection = require('./connection');

--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
     "bluebird": "^3.4.1",
     "carrier": "^0.3.0",
     "chai": "^3.5.0",
-    "collections": "^5.0.4",
     "debug": "^2.2.0",
     "hashring": "^3.2.0",
     "immutable": "^3.8.1",
     "lodash": "^4.14.0",
+    "queue": "^4.0.0",
     "ramda": "^0.21.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -831,12 +831,6 @@ coffee-script@~1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.10.0.tgz#12938bcf9be1948fa006f92e0c4c9e81705108c0"
 
-collections@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/collections/-/collections-5.0.4.tgz#9344874e7f279ef0f8ec5cb50d75d4512e38ec6a"
-  dependencies:
-    weak-map "~1.0.x"
-
 colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
@@ -3621,6 +3615,12 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
+queue:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-4.0.0.tgz#e5b10fa5847c696c64149a40c58d270ad79ac713"
+  dependencies:
+    inherits "~2.0.0"
+
 ramda@^0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"
@@ -4644,10 +4644,6 @@ ware@^1.2.0, ware@1.3.0:
   resolved "https://registry.yarnpkg.com/ware/-/ware-1.3.0.tgz#d1b14f39d2e2cb4ab8c4098f756fe4b164e473d4"
   dependencies:
     wrap-fn "^0.1.0"
-
-weak-map@~1.0.x:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/weak-map/-/weak-map-1.0.5.tgz#79691584d98607f5070bd3b70a40e6bb22e401eb"
 
 webidl-conversions@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
The "collections" package has issues with array shims causing other dependencies to break when least expected. This has been discussed in multiple issues:

 - https://github.com/montagejs/collections/issues/162
 - https://github.com/montagejs/collections/issues/95
 - https://github.com/balderdashy/sails/issues/2524

Another solution to this could also be to depend on "collections@2.0.2" instead, which is a version without shims.

All tests pass with this change, so assuming they cover the queue part this change should be fine.