### PR TITLE
GETS and CAS commands

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -307,6 +307,27 @@ Client.prototype.set = function(key, val, ttl, cb) {
     return this.run('set', [key, val, ttl], cb);
 };
 
+/**
+ * cas() - Set a value for the provided key if the CAS value matches
+ *
+ * @param {String} key - The key to set
+ * @param {*} value - The value to set for this key. Can be of any type
+ * @param {String} cas - A CAS value returned from a 'gets' call
+ * @param {Number|Object|Function} [ttl = 0] - The time to live for this key or callback
+ * @param {Function} [cb] - Callback to call when we have a value
+ * @returns {Promise} with a boolean value indicating if the value was stored (true) or not (false)
+ */
+Client.prototype.cas = function(key, val, cas, ttl, cb) {
+    assert(key, 'Cannot set without key!');
+
+    if (typeof ttl === 'function') {
+        cb = ttl;
+        ttl = 0;
+    }
+
+    return this.run('cas', [key, val, cas, ttl], cb);
+};
+
 
 /**
  * gets() - Get the value and CAS id for the provided key

--- a/lib/client.js
+++ b/lib/client.js
@@ -309,6 +309,24 @@ Client.prototype.set = function(key, val, ttl, cb) {
 
 
 /**
+ * gets() - Get the value and CAS id for the provided key
+ *
+ * @param {String} key - The key to get
+ * @param {Object} opts - Any options for this request
+ * @param {Function} [cb] - The (optional) callback called on completion
+ * @returns {Promise} which is an array containing the value and CAS id
+ */
+Client.prototype.gets = function(key, opts, cb) {
+    assert(key, 'Cannot get without key!');
+    if (typeof opts === 'function' && typeof cb === 'undefined') {
+        cb = opts;
+        opts = {};
+    }
+
+    return this.run('gets', [key, opts], cb);
+};
+
+/**
  * get() - Get the value for the provided key
  *
  * @param {String} key - The key to get

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -686,7 +686,7 @@ Connection.prototype.gets = function(key, opts) {
                                 // like a cache miss. So in the usual workflow the client tries to set it
                                 // again which means the second time around the compressed version is set
                                 // as the client wanted/expected.
-                                return [ null ];
+                                return [ null, null ];
                             } else {
                                 throw err;
                             }
@@ -695,7 +695,7 @@ Connection.prototype.gets = function(key, opts) {
                     return [ convert(data, flag, length), cas ];
                 }
             } else {
-                return [ null ];
+                return [ null, null ];
             }
         });
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -517,6 +517,75 @@ Connection.prototype.set = function(key, val, ttl) {
         });
 };
 
+/**
+ * cas() - Set a value on this connection if the CAS value matches
+ */
+Connection.prototype.cas = function(key, val, cas, ttl) {
+    var self = this;
+    assert(typeof key === 'string', 'Cannot set in memcache with a not string key');
+    assert(key.length < 250, 'Key must be less than 250 characters long');
+
+    ttl = ttl || 0;
+    var opts = {};
+
+    if (_.isObject(ttl)) {
+        opts = ttl;
+        ttl = opts.ttl || 0;
+    }
+
+    var flag = getFlag(val, opts.compressed);
+
+    return formatValue(val, opts.compressed)
+        .bind(this)
+        .then(function(v) {
+            if (opts.compressed) {
+                // Note, we use base64 encoding because this allows us to compress it
+                // but also safely store/retrieve it in memcache. Not quite as efficient
+                // as if we just used the zlib default, but it also includes a bunch of
+                // funky characters that didn't seem to be safe to set/get from memcache
+                // without messing with the data.
+                v = new Buffer(v.toString('base64'));
+            }
+            if (v.length > self.maxValueSize) {
+                throw new Error(util.format('Value too large to set in memcache: %s > %s', v.length, self.maxValueSize));
+            }
+
+            // What we're doing here is a bit tricky as we need to invert control.
+            // We are going to basically return a Promise that itself is made up of a
+            // chain of Promises, most resolved here (the initial communication with
+            // memcache), but the last is not resolved until some time in the future.
+            // This Promise is put into a queue which will be processed whenever the
+            // socket responds (usually immediately). This because we don't know
+            // exactly when it's going to respond since it's an event emitter. So we
+            // are doing some funky promise trickery to convert event emmitter into
+            // Promise/or Callback. Since all actions in this library share the same
+            // queue, order should be maintained and this trick should work!
+
+            var deferred = misc.defer(key);
+            deferred.key = key;
+            this.commandBuffer = this.commandBuffer.push(deferred);
+
+            // First send the metadata for this request
+            this.write(util.format('cas %s %d %d %d %s', key, flag, ttl, v.length, cas));
+
+            // Then the actual value (as a string)
+            this.write(util.format('%s', v));
+            return deferred.promise
+                           .then(function(data) {
+                               // data will be a buffer
+                               if ((data === 'EXISTS') || (data === 'NOT_FOUND')) {
+                                 return Promise.resolve(false);
+
+                               } else if (data !== 'STORED') {
+                                   throw new Error(util.format('Something went wrong with the set. Expected STORED, got :%s:', data.toString()));
+
+                               } else {
+                                   return Promise.resolve(true);
+                               }
+                           });
+        });
+};
+
 function convert(data, flag, length) {
     if (flag & FLAG_NUMERIC) {
         return Number(data);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -268,19 +268,22 @@ Connection.prototype.read = function(data) {
         // last time so now we want to ignore it
         err = new Error(util.format('Memcache returned an error: %s\r\nFor key %s', data, deferred.key));
     } else if (data.match(/^VALUE .+/)) {
-        var spl = data.match(/^VALUE (.+) ([0-9]+) ([0-9]+)$/);
+        var spl = data.match(/^VALUE ([^ ]+) ([0-9]+) ([0-9]+)( ([0-9]+))?$/);
         debug('Got some metadata', spl);
         metadataTemp[spl[1]] = {
             flag: Number(spl[2]),
             len: Number(spl[3])
         };
+        if (spl.length === 6) {
+          metadataTemp[spl[1]].cas = spl[5];
+        }
         done = false;
     } else if (data.match(/^END$/)) {
         if (deferred.type === 'items') {
             resp = this.data;
         } else if (metadataTemp[deferred.key]) {
             var metadata = metadataTemp[deferred.key];
-            resp = [ this.data, metadata.flag, metadata.len ];
+            resp = [ this.data, metadata.flag, metadata.len, metadata.cas ];
             // After we've used this metadata, purge it
             delete metadataTemp[deferred.key];
         } else {
@@ -576,6 +579,56 @@ Connection.prototype.decr = function(key, amount) {
                        }
                    });
     // .timeout() // @todo add this as a setting
+};
+
+/**
+ * gets() - Get a value and CID on this connection
+ *
+ * @param {String} key - The key for the value to retrieve
+ * @param {Object} [opts] - Any additional options for this get
+ * @returns {Promise} - containing an array with the value and CID
+ */
+Connection.prototype.gets = function(key, opts) {
+    opts = opts || {};
+    // Do the gets
+    var deferred = misc.defer(key);
+    this.commandBuffer = this.commandBuffer.push(deferred);
+
+    this.write('gets ' + key);
+
+    return deferred.promise
+    // .timeout() // @todo add this as a setting
+        .spread(function(data, flag, length, cas) {
+            if (data) {
+                if (opts.compressed || (flag & FLAG_COMPRESSED)) {
+                    // @todo compressed data should still be able to utilize the
+                    //  flags to return data of same type set
+                    return misc.decompress(new Buffer(data, 'base64'))
+                        .then(function(d) {
+                            return [ d.toString(), cas ];
+                        })
+                        .catch(function(err) {
+                            if (err.toString().indexOf('Error: incorrect header check') > -1) {
+                                // Basically we get this OperationalError when we try to decompress a value
+                                // which was not previously compressed. We return null instead of bubbling
+                                // this error up the chain because we want to represent it as a cache miss
+                                // rather than an actual error. By looking like a cache miss like this, it
+                                // makes it so someone can turn on compression and it'll work fine, looking
+                                // like a cache miss. So in the usual workflow the client tries to set it
+                                // again which means the second time around the compressed version is set
+                                // as the client wanted/expected.
+                                return [ null ];
+                            } else {
+                                throw err;
+                            }
+                        });
+                } else {
+                    return [ convert(data, flag, length), cas ];
+                }
+            } else {
+                return [ null ];
+            }
+        });
 };
 
 /**

--- a/test/client.js
+++ b/test/client.js
@@ -169,6 +169,7 @@ describe('Client', function() {
                         });
         });
 
+    
         it('works with very large values', function() {
             var key = getKey(), val = chance.word({ length: 1000000 });
 
@@ -573,6 +574,31 @@ describe('Client', function() {
             });
         });
     });
+
+    describe('cas and gets', function() {
+        var cache;
+        before(function() {
+            cache = new Client();
+        });
+
+        it('exists', function() {
+            cache.should.have.property('gets');
+        });
+
+        it('should return a cas value', function() {
+            var key = getKey(), val = chance.word();
+
+            return cache.set(key, val)
+                        .then(function() {
+                            return cache.gets(key);
+                        })
+                        .spread(function(v, cas) {
+                            val.should.equal(v);
+                            expect(cas).to.exist;
+                        });
+        });
+    });
+
     // @todo should have cleanup jobs to delete keys we set in memcache
     describe('delete', function() {
         var cache;

--- a/test/client.js
+++ b/test/client.js
@@ -597,6 +597,67 @@ describe('Client', function() {
                             expect(cas).to.exist;
                         });
         });
+
+        it('should store new value when given a matching cas', function() {
+            var key = getKey(), val = chance.word(), updatedVal = chance.word();
+
+            return cache.set(key, val)
+                        .then(function() {
+                            return cache.gets(key);
+                        })
+                        .spread(function(v, cas) {
+                            return cache.cas(key, updatedVal, cas);
+
+                        }).then(function(success) {
+                            expect(success).to.be.true;
+
+                            return cache.get(key);
+
+                        }).then(function(v) {
+                            expect(v).to.equal(updatedVal);
+
+                        });
+        });
+
+        it('should not store the new value when given an invalid cas value', function() {
+            var key = getKey(), val = chance.word(), updatedVal = chance.word();
+
+            return cache.set(key, val)
+                        .then(function() {
+                            return cache.gets(key);
+                        })
+                        .spread(function(v, cas) {
+                            var invalidCas;
+                            
+                            do {
+                              invalidCas = chance.string({pool: '0123456789', length: 15});
+                            } while (invalidCas === cas);
+
+                            return cache.cas(key, updatedVal, invalidCas);
+
+                        }).then(function(success) {
+                            expect(success).to.be.false;
+
+                        });
+        });
+
+        it('should not store a value when given an invalid key value', function() {
+            var key = getKey(), invalidKey = getKey(),
+                val = chance.word(), updatedVal = chance.word();
+
+            return cache.set(key, val)
+                        .then(function() {
+                            return cache.gets(key);
+                        })
+                        .spread(function(v, cas) {
+                            
+                            return cache.cas(invalidKey, updatedVal, cas);
+
+                        }).then(function(success) {
+                            expect(success).to.be.false;
+
+                        });
+        });
     });
 
     // @todo should have cleanup jobs to delete keys we set in memcache


### PR DESCRIPTION
I added support for the GETS and CAS commands.

The GETS returns an array of [ value, cas ]. I could have returned an object, but I like being able to use .spread(value, cas) to get the results.

For the most part I'm just duplicating the GET and SET code. This should probably be refactored to eliminate the duplication.

I updated the 'VALUE' response parsing regex to exclude spaces in the key so I could add the optional CAS parsing at the end. This should be ok, as the memcache protocol doesn't allow spaces in keys.

I used a string for the CAS value, rather than a number, since the CAS is a 64-bit number and I think Number is a signed 64-bit.

This addresses #21 and a some of #14 