### PR TITLE
Reject on autodiscovery failure

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -151,6 +151,7 @@ Client.prototype.disconnect = function(opts) {
  */
 Client.prototype.getHostList = function() {
 
+    var client = this;
     var connections = {};
     // Promise.any because we don't care which completes first, as soon as we get
     // a list of hosts we can stop
@@ -165,15 +166,24 @@ Client.prototype.getHostList = function() {
                 // Do the autodiscovery, then resolve with hosts
                 return deferred.resolve(this.autodiscovery());
             },
-            onError: this.onNetError
+            onError: function (err) {
+                client.onNetError(err);
+                deferred.reject(err);
+            }
         });
 
         return deferred.promise;
-    }, this)).bind(this).then(function(hosts) {
-        this.hosts = hosts;
-        this.connectToHosts();
-        this.flushBuffer();
-    });
+    }, this)).bind(this).then(
+        function(hosts) {
+            this.hosts = hosts;
+            this.connectToHosts();
+            this.flushBuffer();
+        },
+        function (err) {
+            var wrappedError = new Error('Autodiscovery failed. Errors were:\n' + err.join('\n---\n'));
+            this.flushBuffer(wrappedError);
+        }
+    );
 };
 
 /**
@@ -209,13 +219,22 @@ Client.prototype.connectToHosts = function() {
  *
  * @api private
  */
-Client.prototype.flushBuffer = function() {
+Client.prototype.flushBuffer = function(err) {
+    this.bufferedError = err;
+
     if (this.buffer && this.buffer.size > 0) {
         debug('flushing client write buffer');
         // @todo Watch out for and handle how this behaves with a very long buffer
         while(this.buffer.size > 0) {
             var item = this.buffer.first();
             this.buffer = this.buffer.shift();
+
+            // Something bad happened before things got a chonce to run. We
+            // need to cancel all pending operations.
+            if (err) {
+                item.deferred.reject(err);
+                continue;
+            }
 
             // First, retrieve the correct connection out of the hashring
             var connection = this.connections[this.ring.get(item.key)];
@@ -595,6 +614,8 @@ Client.prototype.run = function(command, args, cb) {
         return connection[command].apply(connection, args).nodeify(cb);
     } else if (this.bufferBeforeError === 0 || !this.queue) {
         return Promise.reject(new Error('Connection is not ready, either not connected yet or disconnected')).nodeify(cb);
+    } else if (this.bufferedError) {
+        return Promise.reject(this.bufferedError).nodeify(cb);
     } else {
         var deferred = misc.defer(args[0]);
 

--- a/test/client.js
+++ b/test/client.js
@@ -129,6 +129,29 @@ describe('Client', function() {
                 });
         });
         */
+
+        it('throws on autodiscovery failure', function() {
+            var cache = new Client({ hosts: ['badserver:11211'], autodiscover: true });
+            var val = chance.word();
+
+            return cache.set('test', val)
+                .then(function() { throw new Error('should not get here'); })
+                .catch(function(err) {
+                    err.should.be.ok;
+                    err.should.be.an.instanceof(Error);
+                    err.message.should.match(/Autodiscovery failed/);
+                })
+                .then(function() {
+                    // try again to ensure that subsequent ops also fail
+                    return cache.set('test', val);
+                })
+                .then(function() { throw new Error('should not get here'); })
+                .catch(function(err) {
+                    err.should.be.ok;
+                    err.should.be.an.instanceof(Error);
+                    err.message.should.match(/Autodiscovery failed/);
+                });
+        });
     });
 
     describe('set and get', function() {


### PR DESCRIPTION
When autodiscovery fails cache operations are silently queued and
are never dequeued. This leaves the client in an unusable state and
only warns the consumer if onNetError is provided. Since failed
autodiscovery is not recoverable all queued operations should be
rejected.

Related to #36.