### PR TITLE
Add timeout on cache operations

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -613,8 +613,8 @@ Connection.prototype.incr = function(key, amount) {
                        } else {
                            return Number(v);
                        }
-                   });
-    // .timeout() // @todo add this as a setting
+                   })
+                   .timeout(this.netTimeout);
 };
 
 /**
@@ -635,8 +635,8 @@ Connection.prototype.decr = function(key, amount) {
                        } else {
                            return Number(v);
                        }
-                   });
-    // .timeout() // @todo add this as a setting
+                   })
+                   .timeout(this.netTimeout);
 };
 
 /**
@@ -655,7 +655,7 @@ Connection.prototype.gets = function(key, opts) {
     this.write('gets ' + key);
 
     return deferred.promise
-    // .timeout() // @todo add this as a setting
+        .timeout(this.netTimeout)
         .spread(function(data, flag, length, cas) {
             if (data) {
                 if (opts.compressed || (flag & FLAG_COMPRESSED)) {
@@ -705,7 +705,7 @@ Connection.prototype.get = function(key, opts) {
     this.write('get ' + key);
 
     return deferred.promise
-    // .timeout() // @todo add this as a setting
+        .timeout(this.netTimeout)
         .spread(function(data, flag, length) {
             if (data) {
                 if (opts.compressed || (flag & FLAG_COMPRESSED)) {
@@ -972,8 +972,8 @@ Connection.prototype.delete = function(key) {
                        } else {
                            return false;
                        }
-                   });
-    // .timeout() // @todo add this as a setting
+                   })
+                   .timeout(this.netTimeout);
 };
 
 /**


### PR DESCRIPTION
Under some circumstances, the client might appear connected while the
server won't respond is a reasonable timeframe. Without this timeout,
the operation will be pending without ever resolving.

This is working fine for my use case: catching the bluebird timeout to respond with fallback data.

I saw the `TODO` comments so basically added a timeout everywhere.
The limit value is `netTimeout` which seems relevant but maybe you had another setting in mind?