### PR TITLE
Assertion Key length by bytes and control characters

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -18,7 +18,7 @@ function validateKey(key, operation) {
     misc.assert(typeof key === 'string', 'Key needs to be of type "string"');
     misc.assert(Buffer.byteLength(key) < 250, 'Key must be less than 250 characters long');
     misc.assert(key.length < 250, 'Key must be less than 250 characters long');
-    misc.assert(!/[\x00-\x20]/.test(key), 'Key must not include control characters or whitespace.');
+    misc.assert(!/[\x00-\x20]/.test(key), 'Key must not include control characters or whitespace');
 }
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -16,7 +16,9 @@ var Connection = require('./connection');
 function validateKey(key, operation) {
     misc.assert(key, 'Cannot "' + operation + '" without key!');
     misc.assert(typeof key === 'string', 'Key needs to be of type "string"');
+    misc.assert(Buffer.byteLength(key) < 250, 'Key must be less than 250 characters long');
     misc.assert(key.length < 250, 'Key must be less than 250 characters long');
+    misc.assert(!/[\x00-\x20]/.test(key), 'Key must not include control characters or whitespace.');
 }
 
 /**


### PR DESCRIPTION
Changed key length to assert by bytes length instead of char length
closes #65 

Added assertion for non control characters or whitespace key
closes #52