### PR TITLE
Add support for IPC connections to the memcached

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -174,7 +174,13 @@ Connection.prototype.connect = function() {
         params.host = self.host;
     }
 
-    debug('connecting to host %s:%s', params.host, params.port);
+    // Connect via IPC if port equals to 0.
+    if (parseInt(params.port, 10) === 0 && params.host) {
+        params = params.host;
+        debug('connecting to unix socket %s', params);
+    } else {
+        debug('connecting to host %s:%s', params.host, params.port);
+    }   
 
     // If a client already exists, we just want to reconnect
     if (this.client) {


### PR DESCRIPTION
Relates to #78 

That is my suggestion to be able to connect to the memcached via IPC.
If port set to zero, module will try to establish connection via IPC by using host parameter as a socket path.