### PR TITLE
fix: propagate netTimeout option to Connection instances

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -171,7 +171,8 @@ Client.prototype.getHostList = function() {
             onError: function (err) {
                 client.onNetError(err);
                 deferred.reject(err);
-            }
+            },
+            netTimeout: this.netTimeout
         });
 
         return deferred.promise;
@@ -209,7 +210,8 @@ Client.prototype.connectToHosts = function() {
             },
             bufferBeforeError: this.bufferBeforeError,
             onError: this.onNetError,
-            maxValueSize: this.maxValueSize
+            maxValueSize: this.maxValueSize,
+            netTimeout: this.netTimeout
         });
     }, this);
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -123,7 +123,7 @@ function Connection(opts) {
         this.onError = function onError(err) { this.emit('error'); console.error(err); };
     }
     this.bufferBeforeError = opts.bufferBeforeError;
-    this.netTimeout = opts.netTimeout || 500;
+    this.netTimeout = ('netTimeout' in opts) ? opts.netTimeout : 500;
     this.backoffLimit = opts.backoffLimit || 10000;
     this.reconnect = opts.reconnect;
     this.disconnecting = false;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "memcache-plus",
+  "name": "@feedfm/memcache-plus",
   "version": "0.2.22",
   "description": "Better memcache for node",
   "main": "index.js",


### PR DESCRIPTION
The 'netTimeout' option passed to a Client instance was not being passed on to Connection instances.