### PR TITLE
Add TLS support.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -52,7 +52,8 @@ function Client(opts) {
         queue: true,
         netTimeout: 500,
         backoffLimit: 10000,
-        maxValueSize: 1048576
+        maxValueSize: 1048576,
+        tls: null
     });
 
     // Iterate over options, assign each to this object
@@ -165,6 +166,7 @@ Client.prototype.getHostList = function() {
             port: h.port,
             netTimeout: this.netTimeout,
             reconnect: false,
+            tls: this.tls,
             onConnect: function() {
                 // Do the autodiscovery, then resolve with hosts
                 return deferred.resolve(this.autodiscovery());
@@ -196,6 +198,7 @@ Client.prototype.getHostList = function() {
  */
 Client.prototype.connectToHosts = function() {
     debug('connecting to all hosts');
+
     this.hosts.forEach(function(host) {
         var h = this.splitHost(host);
         var client = this;
@@ -211,7 +214,8 @@ Client.prototype.connectToHosts = function() {
             bufferBeforeError: this.bufferBeforeError,
             netTimeout: this.netTimeout,
             onError: this.onNetError,
-            maxValueSize: this.maxValueSize
+            maxValueSize: this.maxValueSize,
+            tls: this.tls
         });
     }, this);
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -9,6 +9,7 @@ var _ = require('lodash'),
     carrier = require('carrier'),
     misc = require('./misc'),
     net = require('net'),
+    tls = require('tls'),
     Immutable = require('immutable'),
     Promise = require('bluebird'),
     util = require('util'),
@@ -105,11 +106,13 @@ function Connection(opts) {
         host: 'localhost',
         port: '11211',
         reconnect: true,
-        maxValueSize: 1048576
+        maxValueSize: 1048576,
+        tls: null
     });
 
     this.host = opts.host;
     this.port = opts.port;
+    this.tls = opts.tls;
 
     this.commandBuffer = new Immutable.List();
 
@@ -182,7 +185,12 @@ Connection.prototype.connect = function() {
 
     } else {
         // Initialize a new client, connect
-        self.client = net.connect(params);
+        if (self.tls === null) {
+            self.client = net.connect(params);
+        } else {
+            params.tls = self.tls;
+            self.client = tls.connect(params);
+        }
         self.client.setTimeout(self.netTimeout);
         self.client.on('error', self.onError);
         self.client.setNoDelay(true);
@@ -251,7 +259,7 @@ Connection.prototype.read = function(data) {
             // Do nothing with this for now
             var configItems = data.match(/^CONFIG cluster ([0-9]+) ([0-9]+)/);
             this.autodiscover.len = Number(configItems[2]);
-        } else if (this.autodiscover.len !== undefined && data.match(/^([0-9])+/)) {
+        } else if (this.autodiscover.len !== undefined && this.autodiscover.version === undefined && data.match(/^([0-9])+/)) {
             this.autodiscover.version = Number(data);
         } else if (data.match(/^END$/)) {
             resp = this.autodiscover;

--- a/test/client.js
+++ b/test/client.js
@@ -121,6 +121,25 @@ describe('Client', function() {
         });
 
         /**
+         *  To run this test, start up a local memcached server with TLS enabled
+         *  on port 11212 with a trusted certificate
+         */
+        it('with TLS enabled', async function() {
+            var cache_client = new Client({
+                hosts: ['127.0.0.1:11212'],
+                tls: {
+                    checkServerIdentity: () => {
+                        return undefined;
+                    }
+                }
+            });
+            var val = chance.word();
+            await cache_client.set('key', val);
+            let v = await cache_client.get('key');
+            val.should.equal(v);
+        });
+
+        /**
          * Only comment this out when we have an Elasticache autodiscovery cluster to test against.
          *   Ideally one day this can be mocked, but for now just selectively enabling it
         it('supports autodiscovery', function() {


### PR DESCRIPTION
If the memcached server is configured with TLS, you can make the client connect to it via specifying the `tls` option when creating the client object.

For production environments, the server should be using a TLS certificate that is signed by a trusted public CA. In
this case you can simply do the following to create the client:

```
const client = new Client({ hosts: ['{server_hostname}:11211'], tls: {} });
client.set("key", "value");
```
If the server requires client certificate authentication, you can do the following:

```
var fs = require('fs');
const client = new Client({ hosts: ['{server_hostname}:11211'], tls: {
  key: fs.readFileSync("client-key.pem"),
  cert: fs.readFileSync("client-cert.pem")
}});
client.set("key", "value");
```

If you are running the server with a self-signed certificate (i.e. for local developments), you can create the client
by specifying the CA certificate and disable hostname verification as follows:

```
var fs = require('fs');
const client = new Client({ hosts: ['{server_hostname}:11211'], tls: {
  ca: fs.readFileSync("ca-cert.pem"),
  checkServerIdentity: () => {return undefined;}
}});
client.set("key", "value");
```
I also had to fix a bug in the elasticache auto-discovery response parsing logic. ElastiCache TLS enabled memcached clusters changed the format of the hostnames so that they begin with a number, i.e. `0001.victor.di6cba.use1.cache.amazonaws.com` instead of the previous format `victor.di6cba.0001.use1.cache.amazonaws.com`. This broke the previous logic for version detection.

I tested this change against a local memcached server and against a remote memcached server with TLS enabled. Test case is added as well.