### PR TITLE
Allow changing of HashRing hash algorithm

### DIFF
--- a/docs/initialization.md
+++ b/docs/initialization.md
@@ -151,6 +151,7 @@ object containing any of the following options (default values in parentheses):
 |`queue`| `true` | Whether or not to queue commands issued before a connection is established or if the connection is dropped momentarily. |
 |`netTimeout`|500| Number of milliseconds to wait before assuming there is a network timeout. |
 |`reconnect` | `true` | Whether or not to automatically reconnect if the connection is lost. Memcache Plus includes an exponential backoff to prevent it from spamming a server that is offline |
+|`hashAlgorithm` | `md5` | Hash Algorithm to be used when creating hashring of servers
 
 Example:
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -55,7 +55,8 @@ function Client(opts) {
         backoffLimit: 10000,
         maxValueSize: 1048576,
         poolSize: 1,
-        tls: null
+        tls: null,
+        hashAlgorithm: 'md5',
     });
 
     // Iterate over options, assign each to this object
@@ -92,7 +93,7 @@ Client.prototype.connect = function() {
                 debug('got host list, connecting to hosts');
                 // Connect to these hosts
                 this.connectToHosts();
-                this.ring = new HashRing(_.keys(this.connections));
+                this.ring = new HashRing(_.keys(this.connections), this.hashAlgorithm);
             });
 
         // Then get the list of servers
@@ -225,7 +226,7 @@ Client.prototype.connectToHosts = function() {
         });
     }, this);
 
-    this.ring = new HashRing(_.keys(this.connections));
+    this.ring = new HashRing(_.keys(this.connections), this.hashAlgorithm);
 };
 
 /**


### PR DESCRIPTION
Allow an option to set the hash algorithm that will be used when calling `HashRing`.  In environments that require FIPS validated encryption hash algorithms like MD5 are not permitted.  This change will allow the option to use approved hash algorithms (eg: SHA256) while retaining backwards compatibility.